### PR TITLE
[codex] simplify dogo-cam to manual-only Raspberry Pi control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .env
+.venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/PIN_DIAGRAM.md
+++ b/PIN_DIAGRAM.md
@@ -1,0 +1,167 @@
+# Raspberry Pi Pin Diagram - Complete Hardware Setup
+
+## Raspberry Pi 3 GPIO Pinout (40-pin header)
+
+```
+         3.3V [ 1] [2 ] 5V
+        GPIO2 [ 3] [4 ] 5V
+        GPIO3 [ 5] [6 ] GND         ← Button G (ground)
+        GPIO4 [ 7] [8 ] GPIO14
+          GND [ 9] [10] GPIO15
+       GPIO17 [11] [12] GPIO18      ← LED Control (Option 2)
+       GPIO27 [13] [14] GND
+       GPIO22 [15] [16] GPIO23
+         3.3V [17] [18] GPIO24      ← Button V (power)
+       GPIO10 [19] [20] GND
+        GPIO9 [21] [22] GPIO25
+       GPIO11 [23] [24] GPIO8
+          GND [25] [26] GPIO7
+        GPIO0 [27] [28] GPIO1
+        GPIO5 [29] [30] GND
+        GPIO6 [31] [32] GPIO12
+       GPIO13 [33] [34] GND
+       GPIO19 [35] [36] GPIO16
+       GPIO26 [37] [38] GPIO20
+          GND [39] [40] GPIO21
+```
+
+## Pin Usage Summary
+
+### DHT22 Temperature/Humidity Sensor
+
+| Sensor Pin | Connected To | Physical Pin | GPIO/Function |
+|------------|--------------|--------------|---------------|
+| VCC (Red) | 3.3V Power | **Pin 1** | 3.3V |
+| Data (Yellow) | Data Signal | **Pin 7** | GPIO4 |
+| GND (Black) | Ground | **Pin 9** | GND |
+
+**Pull-up Resistor**: 4.7kΩ-10kΩ between VCC and Data pins
+
+### G-V-S Button Module - Option 1 (Simple Mode)
+
+| Button Pin | Connected To | Physical Pin | GPIO/Function |
+|------------|--------------|--------------|---------------|
+| G (Ground) | Ground | **Pin 6** | GND |
+| V (Power) | 3.3V Power | **Pin 17** | 3.3V |
+| S (Signal) | Button Input | **Pin 5** | GPIO3 |
+
+**LED Behavior**: Always ON when Pi is powered
+
+### G-V-S Button Module - Option 2 (Full LED Control)
+
+| Connection | Connected To | Physical Pin | GPIO/Function |
+|------------|--------------|--------------|---------------|
+| G (LED GND) | Ground | **Pin 6** | GND |
+| V (LED Power) | 3.3V Power | **Pin 17** | 3.3V |
+| S (LED Control) | LED Signal | **Pin 11** | GPIO17 |
+| Button Switch 1* | Button Input | **Pin 5** | GPIO3 |
+| Button Switch 2* | Ground | **Pin 6** | GND |
+
+*Internal button switch contacts (requires opening module or testing with multimeter)
+
+**LED Behavior**: Blinks based on system state (slow/medium/fast/solid/off)
+
+## Visual Pin Diagram - Option 1 (Simple)
+
+```
+Raspberry Pi GPIO Header
+┌─────────────────────────────────────────┐
+│                                         │
+│  [1]  3.3V ●━━━━━━━━━━━━━━━━━━━━━┓    │  DHT22 VCC (Red wire)
+│                                   ┃    │
+│  [2]  5V                          ┃    │
+│  [3]  GPIO2                       ┃    │
+│  [4]  5V                          ┃    │
+│  [5]  GPIO3 ●━━━━━━━━━━━━━━━┓    ┃    │  Button S (Signal)
+│                             ┃    ┃    │
+│  [6]  GND   ●━━━━━━━━━┓    ┃    ┃    │  Button G (Ground)
+│                       ┃    ┃    ┃    │
+│  [7]  GPIO4 ●━━━━┓   ┃    ┃    ┃    │  DHT22 Data (Yellow wire)
+│                  ┃   ┃    ┃    ┃    │
+│  [8]  GPIO14     ┃   ┃    ┃    ┃    │
+│  [9]  GND   ●━━━━┫   ┃    ┃    ┃    │  DHT22 GND (Black wire)
+│                  ┃   ┃    ┃    ┃    │
+│  [10] GPIO15     ┃   ┃    ┃    ┃    │
+│  [11] GPIO17     ┃   ┃    ┃    ┃    │
+│  [12] GPIO18     ┃   ┃    ┃    ┃    │
+│  [13] GPIO27     ┃   ┃    ┃    ┃    │
+│  [14] GND        ┃   ┃    ┃    ┃    │
+│  [15] GPIO22     ┃   ┃    ┃    ┃    │
+│  [16] GPIO23     ┃   ┃    ┃    ┃    │
+│  [17] 3.3V  ●━━━━┫━━━┫━━━━┫━━━━┫━┓  │  Button V (Power)
+│                  ┃   ┃    ┃    ┃ ┃  │
+│       ...        ┃   ┃    ┃    ┃ ┃  │
+└─────────────────────────────────────────┘
+                   ┃   ┃    ┃    ┃ ┃
+                   ┃   ┃    ┃    ┃ ┃
+      To DHT22: ━━━┻━━━┻━━━━┛    ┃ ┃
+      (GND, Data, VCC)            ┃ ┃
+                                  ┃ ┃
+      To Button: ━━━━━━━━━━━━━━━━┻━┻
+      (GND, Signal, Power)
+```
+
+## Visual Pin Diagram - Option 2 (Full LED Control)
+
+```
+Raspberry Pi GPIO Header
+┌─────────────────────────────────────────┐
+│                                         │
+│  [1]  3.3V ●━━━━━━━━━━━━━━━━━━━━━┓    │  DHT22 VCC (Red wire)
+│                                   ┃    │
+│  [2]  5V                          ┃    │
+│  [3]  GPIO2                       ┃    │
+│  [4]  5V                          ┃    │
+│  [5]  GPIO3 ●━━━━━━━━━━━━━━━┓    ┃    │  Button Switch Contact 1
+│                             ┃    ┃    │
+│  [6]  GND   ●━━━━━━━━━┓━━━━┫    ┃    │  Button G + Switch Contact 2
+│                       ┃    ┃    ┃    │
+│  [7]  GPIO4 ●━━━━┓   ┃    ┃    ┃    │  DHT22 Data (Yellow wire)
+│                  ┃   ┃    ┃    ┃    │
+│  [8]  GPIO14     ┃   ┃    ┃    ┃    │
+│  [9]  GND   ●━━━━┫   ┃    ┃    ┃    │  DHT22 GND (Black wire)
+│                  ┃   ┃    ┃    ┃    │
+│  [10] GPIO15     ┃   ┃    ┃    ┃    │
+│  [11] GPIO17 ●━━━┫━━━┫━━━━┫━━━━┫━┓  │  Button S (LED Control)
+│                  ┃   ┃    ┃    ┃ ┃  │
+│  [12] GPIO18     ┃   ┃    ┃    ┃ ┃  │
+│  [13] GPIO27     ┃   ┃    ┃    ┃ ┃  │
+│  [14] GND        ┃   ┃    ┃    ┃ ┃  │
+│  [15] GPIO22     ┃   ┃    ┃    ┃ ┃  │
+│  [16] GPIO23     ┃   ┃    ┃    ┃ ┃  │
+│  [17] 3.3V  ●━━━━┫━━━┫━━━━┫━━━━┫━┫  │  Button V (LED Power)
+│                  ┃   ┃    ┃    ┃ ┃  │
+│       ...        ┃   ┃    ┃    ┃ ┃  │
+└─────────────────────────────────────────┘
+                   ┃   ┃    ┃    ┃ ┃
+      To DHT22: ━━━┻━━━┻━━━━┛    ┃ ┃
+      (GND, Data, VCC)            ┃ ┃
+                                  ┃ ┃
+      To Button LED: ━━━━━━━━━━━━┻━┻
+      (GND, GPIO17, Power)
+
+      To Button Switch: ━━━━━━━━━━┻
+      (Contact 1=GPIO3, Contact 2=GND)
+```
+
+## Quick Reference Table - All Pins Used
+
+| Physical Pin | GPIO/Function | Connected To (Option 1) | Connected To (Option 2) |
+|--------------|---------------|-------------------------|-------------------------|
+| Pin 1 | 3.3V | DHT22 VCC | DHT22 VCC |
+| Pin 5 | GPIO3 | Button S (signal) | Button Switch Contact 1 |
+| Pin 6 | GND | Button G (ground) | Button G + Switch Contact 2 |
+| Pin 7 | GPIO4 | DHT22 Data | DHT22 Data |
+| Pin 9 | GND | DHT22 GND | DHT22 GND |
+| Pin 11 | GPIO17 | Not used | Button S (LED control) |
+| Pin 17 | 3.3V | Button V (power) | Button V (LED power) |
+
+## Important Notes
+
+1. **No Pin Conflicts**: Each component uses unique pins - no sharing except ground
+2. **3.3V Pins**:
+   - Pin 1 used for DHT22 sensor
+   - Pin 17 used for button LED power
+3. **Ground Pins**: Multiple devices can share ground (Pin 6, Pin 9)
+4. **GPIO3 Wake Feature**: GPIO3 (Pin 5) can wake the Pi from powered-off state
+5. **Pull-up Resistor**: Required between DHT22 VCC and Data pins (4.7kΩ-10kΩ)

--- a/PIN_DIAGRAM.md
+++ b/PIN_DIAGRAM.md
@@ -1,17 +1,28 @@
-# Raspberry Pi Pin Diagram - Complete Hardware Setup
+# Raspberry Pi Wiring
 
-## Raspberry Pi 3 GPIO Pinout (40-pin header)
+This is the wiring for the current manual-only `dogo-cam` setup.
 
-```
+## GPIO Summary
+
+| Device | Function | GPIO | Physical Pin |
+|--------|----------|------|--------------|
+| DHT22 | Data | `GPIO4` | `Pin 7` |
+| Toggle switch | On/off signal | `GPIO17` | `Pin 11` |
+| Tilt servo | PWM signal | `GPIO18` | `Pin 12` |
+| Pan servo | PWM signal | `GPIO19` | `Pin 35` |
+
+## 40-Pin Header View
+
+```text
          3.3V [ 1] [2 ] 5V
         GPIO2 [ 3] [4 ] 5V
-        GPIO3 [ 5] [6 ] GND         ← Button G (ground)
+        GPIO3 [ 5] [6 ] GND
         GPIO4 [ 7] [8 ] GPIO14
           GND [ 9] [10] GPIO15
-       GPIO17 [11] [12] GPIO18      ← LED Control (Option 2)
+       GPIO17 [11] [12] GPIO18
        GPIO27 [13] [14] GND
        GPIO22 [15] [16] GPIO23
-         3.3V [17] [18] GPIO24      ← Button V (power)
+         3.3V [17] [18] GPIO24
        GPIO10 [19] [20] GND
         GPIO9 [21] [22] GPIO25
        GPIO11 [23] [24] GPIO8
@@ -25,143 +36,55 @@
           GND [39] [40] GPIO21
 ```
 
-## Pin Usage Summary
+## DHT22
 
-### DHT22 Temperature/Humidity Sensor
+| DHT22 Pin | Connect To | Raspberry Pi Pin |
+|-----------|------------|------------------|
+| VCC | 3.3V | `Pin 1` |
+| Data | `GPIO4` | `Pin 7` |
+| GND | Ground | `Pin 9` |
 
-| Sensor Pin | Connected To | Physical Pin | GPIO/Function |
-|------------|--------------|--------------|---------------|
-| VCC (Red) | 3.3V Power | **Pin 1** | 3.3V |
-| Data (Yellow) | Data Signal | **Pin 7** | GPIO4 |
-| GND (Black) | Ground | **Pin 9** | GND |
+Use a `4.7kΩ` to `10kΩ` pull-up resistor between DHT22 `VCC` and `Data`.
 
-**Pull-up Resistor**: 4.7kΩ-10kΩ between VCC and Data pins
+## Toggle Switch
 
-### G-V-S Button Module - Option 1 (Simple Mode)
+The current switch is a simple on/off switch used by `ky004-control.py`.
 
-| Button Pin | Connected To | Physical Pin | GPIO/Function |
-|------------|--------------|--------------|---------------|
-| G (Ground) | Ground | **Pin 6** | GND |
-| V (Power) | 3.3V Power | **Pin 17** | 3.3V |
-| S (Signal) | Button Input | **Pin 5** | GPIO3 |
+| Switch Side | Connect To | Raspberry Pi Pin |
+|-------------|------------|------------------|
+| Side A | `GPIO17` | `Pin 11` |
+| Side B | Ground | `Pin 6` or `Pin 9` |
 
-**LED Behavior**: Always ON when Pi is powered
+Behavior:
 
-### G-V-S Button Module - Option 2 (Full LED Control)
+- switch closed to ground: site stack starts
+- switch open: site stack stops
 
-| Connection | Connected To | Physical Pin | GPIO/Function |
-|------------|--------------|--------------|---------------|
-| G (LED GND) | Ground | **Pin 6** | GND |
-| V (LED Power) | 3.3V Power | **Pin 17** | 3.3V |
-| S (LED Control) | LED Signal | **Pin 11** | GPIO17 |
-| Button Switch 1* | Button Input | **Pin 5** | GPIO3 |
-| Button Switch 2* | Ground | **Pin 6** | GND |
+## Servo Wiring
 
-*Internal button switch contacts (requires opening module or testing with multimeter)
+The app uses two MG90S servos:
 
-**LED Behavior**: Blinks based on system state (slow/medium/fast/solid/off)
+- `servo1`: tilt
+- `servo2`: pan
 
-## Visual Pin Diagram - Option 1 (Simple)
+### Tilt Servo
 
-```
-Raspberry Pi GPIO Header
-┌─────────────────────────────────────────┐
-│                                         │
-│  [1]  3.3V ●━━━━━━━━━━━━━━━━━━━━━┓    │  DHT22 VCC (Red wire)
-│                                   ┃    │
-│  [2]  5V                          ┃    │
-│  [3]  GPIO2                       ┃    │
-│  [4]  5V                          ┃    │
-│  [5]  GPIO3 ●━━━━━━━━━━━━━━━┓    ┃    │  Button S (Signal)
-│                             ┃    ┃    │
-│  [6]  GND   ●━━━━━━━━━┓    ┃    ┃    │  Button G (Ground)
-│                       ┃    ┃    ┃    │
-│  [7]  GPIO4 ●━━━━┓   ┃    ┃    ┃    │  DHT22 Data (Yellow wire)
-│                  ┃   ┃    ┃    ┃    │
-│  [8]  GPIO14     ┃   ┃    ┃    ┃    │
-│  [9]  GND   ●━━━━┫   ┃    ┃    ┃    │  DHT22 GND (Black wire)
-│                  ┃   ┃    ┃    ┃    │
-│  [10] GPIO15     ┃   ┃    ┃    ┃    │
-│  [11] GPIO17     ┃   ┃    ┃    ┃    │
-│  [12] GPIO18     ┃   ┃    ┃    ┃    │
-│  [13] GPIO27     ┃   ┃    ┃    ┃    │
-│  [14] GND        ┃   ┃    ┃    ┃    │
-│  [15] GPIO22     ┃   ┃    ┃    ┃    │
-│  [16] GPIO23     ┃   ┃    ┃    ┃    │
-│  [17] 3.3V  ●━━━━┫━━━┫━━━━┫━━━━┫━┓  │  Button V (Power)
-│                  ┃   ┃    ┃    ┃ ┃  │
-│       ...        ┃   ┃    ┃    ┃ ┃  │
-└─────────────────────────────────────────┘
-                   ┃   ┃    ┃    ┃ ┃
-                   ┃   ┃    ┃    ┃ ┃
-      To DHT22: ━━━┻━━━┻━━━━┛    ┃ ┃
-      (GND, Data, VCC)            ┃ ┃
-                                  ┃ ┃
-      To Button: ━━━━━━━━━━━━━━━━┻━┻
-      (GND, Signal, Power)
-```
+| Servo Wire | Connect To |
+|------------|------------|
+| Signal | `GPIO18` / `Pin 12` |
+| Power | external `5V` recommended |
+| Ground | shared ground with Raspberry Pi |
 
-## Visual Pin Diagram - Option 2 (Full LED Control)
+### Pan Servo
 
-```
-Raspberry Pi GPIO Header
-┌─────────────────────────────────────────┐
-│                                         │
-│  [1]  3.3V ●━━━━━━━━━━━━━━━━━━━━━┓    │  DHT22 VCC (Red wire)
-│                                   ┃    │
-│  [2]  5V                          ┃    │
-│  [3]  GPIO2                       ┃    │
-│  [4]  5V                          ┃    │
-│  [5]  GPIO3 ●━━━━━━━━━━━━━━━┓    ┃    │  Button Switch Contact 1
-│                             ┃    ┃    │
-│  [6]  GND   ●━━━━━━━━━┓━━━━┫    ┃    │  Button G + Switch Contact 2
-│                       ┃    ┃    ┃    │
-│  [7]  GPIO4 ●━━━━┓   ┃    ┃    ┃    │  DHT22 Data (Yellow wire)
-│                  ┃   ┃    ┃    ┃    │
-│  [8]  GPIO14     ┃   ┃    ┃    ┃    │
-│  [9]  GND   ●━━━━┫   ┃    ┃    ┃    │  DHT22 GND (Black wire)
-│                  ┃   ┃    ┃    ┃    │
-│  [10] GPIO15     ┃   ┃    ┃    ┃    │
-│  [11] GPIO17 ●━━━┫━━━┫━━━━┫━━━━┫━┓  │  Button S (LED Control)
-│                  ┃   ┃    ┃    ┃ ┃  │
-│  [12] GPIO18     ┃   ┃    ┃    ┃ ┃  │
-│  [13] GPIO27     ┃   ┃    ┃    ┃ ┃  │
-│  [14] GND        ┃   ┃    ┃    ┃ ┃  │
-│  [15] GPIO22     ┃   ┃    ┃    ┃ ┃  │
-│  [16] GPIO23     ┃   ┃    ┃    ┃ ┃  │
-│  [17] 3.3V  ●━━━━┫━━━┫━━━━┫━━━━┫━┫  │  Button V (LED Power)
-│                  ┃   ┃    ┃    ┃ ┃  │
-│       ...        ┃   ┃    ┃    ┃ ┃  │
-└─────────────────────────────────────────┘
-                   ┃   ┃    ┃    ┃ ┃
-      To DHT22: ━━━┻━━━┻━━━━┛    ┃ ┃
-      (GND, Data, VCC)            ┃ ┃
-                                  ┃ ┃
-      To Button LED: ━━━━━━━━━━━━┻━┻
-      (GND, GPIO17, Power)
+| Servo Wire | Connect To |
+|------------|------------|
+| Signal | `GPIO19` / `Pin 35` |
+| Power | external `5V` recommended |
+| Ground | shared ground with Raspberry Pi |
 
-      To Button Switch: ━━━━━━━━━━┻
-      (Contact 1=GPIO3, Contact 2=GND)
-```
+## Power Notes
 
-## Quick Reference Table - All Pins Used
-
-| Physical Pin | GPIO/Function | Connected To (Option 1) | Connected To (Option 2) |
-|--------------|---------------|-------------------------|-------------------------|
-| Pin 1 | 3.3V | DHT22 VCC | DHT22 VCC |
-| Pin 5 | GPIO3 | Button S (signal) | Button Switch Contact 1 |
-| Pin 6 | GND | Button G (ground) | Button G + Switch Contact 2 |
-| Pin 7 | GPIO4 | DHT22 Data | DHT22 Data |
-| Pin 9 | GND | DHT22 GND | DHT22 GND |
-| Pin 11 | GPIO17 | Not used | Button S (LED control) |
-| Pin 17 | 3.3V | Button V (power) | Button V (LED power) |
-
-## Important Notes
-
-1. **No Pin Conflicts**: Each component uses unique pins - no sharing except ground
-2. **3.3V Pins**:
-   - Pin 1 used for DHT22 sensor
-   - Pin 17 used for button LED power
-3. **Ground Pins**: Multiple devices can share ground (Pin 6, Pin 9)
-4. **GPIO3 Wake Feature**: GPIO3 (Pin 5) can wake the Pi from powered-off state
-5. **Pull-up Resistor**: Required between DHT22 VCC and Data pins (4.7kΩ-10kΩ)
+- Do not rely on weak USB power if both servos move under load.
+- Use a power source that can handle the camera and both servos safely.
+- Always connect the servo ground and Raspberry Pi ground together.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,41 @@ Tracking has been removed. The current app is manual-only.
 - Raspberry Pi with Raspberry Pi OS
 - CSI camera module
 - 2 MG90S servos for pan and tilt
+- GPIO toggle switch for turning the site stack on and off
 - optional DHT22 sensor on `GPIO4`
-- optional KY-004 button
+- optional Cloudflare Tunnel
 
 See `PIN_DIAGRAM.md` for wiring.
+
+### Raspberry Pi Wiring
+
+| Part | Signal Pin | Raspberry Pi Pin | Notes |
+|------|------------|------------------|-------|
+| Tilt servo | PWM signal | `GPIO18` / physical `Pin 12` | Servo 1 in the app |
+| Pan servo | PWM signal | `GPIO19` / physical `Pin 35` | Servo 2 in the app |
+| Toggle switch | Switch signal | `GPIO17` / physical `Pin 11` | Closing the switch to ground turns the site stack on |
+| Toggle switch | Ground | physical `Pin 6` or `Pin 9` | Open switch turns the site stack off |
+| DHT22 data | Data | `GPIO4` / physical `Pin 7` | Optional sensor |
+
+### Servo Power Notes
+
+- Use a stable `5V` supply sized for both MG90S servos.
+- Share ground between the servo power supply and the Raspberry Pi.
+- The app maps `servo1` to tilt on `GPIO18` and `servo2` to pan on `GPIO19`.
+- The camera mount is inverted, so the stream is flipped in software.
+
+### Switch Behavior
+
+The deployed Raspberry Pi uses a simple on/off switch on `GPIO17`, monitored by `ky004-control.py`.
+
+- switch ON, `GPIO17` pulled low to ground:
+  - start `dog-stream.service`
+  - wait for the Flask app to respond
+  - start `cloudflared-tunnel.service`
+- switch OFF, `GPIO17` floating high:
+  - signal the Flask app to stop the camera cleanly
+  - stop the Cloudflare tunnel
+  - stop the Flask app
 
 ## Manual Controls
 
@@ -127,15 +158,17 @@ sudo systemctl enable --now dog-stream.service
 sudo systemctl status dog-stream.service
 ```
 
-### Optional button service
+### Switch control service
 
-If you use the KY-004 button:
+If you use the GPIO switch on `GPIO17`:
 
 ```bash
 sudo cp service_startup/button-control.service /etc/systemd/system/button-control.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now button-control.service
 ```
+
+This service runs `ky004-control.py`, which monitors the switch and starts or stops the camera stack.
 
 Update the unit path if your project directory is different.
 

--- a/README.md
+++ b/README.md
@@ -1,307 +1,173 @@
-# Dogo Cam Project 🐶
+# Dogo Cam
 
-This project sets up a Raspberry Pi 3 to stream live video from a camera module (e.g., for monitoring a pet like a dog) and display environmental temperature/humidity data from a sensor.
+Manual Raspberry Pi dog camera with:
 
-![raspberry-pi-image](https://github.com/gabrielAHN/dogo-cam-project/blob/main/img/raspberry-pi-cam.png?raw=true)
+- Flask web UI
+- live Picamera2 stream
+- pan and tilt servo controls
+- keyboard and on-screen arrow controls
+- touch drag controls on mobile
+- optional DHT22 temperature and humidity readout
+- optional Cloudflare Tunnel exposure
 
-The stream is accessible via a web interface with basic authentication, limited to a maximum of 3 concurrent viewers. It uses Flask for the web app, Picamera2 for video, and Adafruit libraries for the sensor.
+Tracking has been removed. The current app is manual-only.
 
-![Dog View](https://github.com/gabrielAHN/dogo-cam-project/blob/main/img/dog-stream.png?raw=true)
+## Project Layout
 
-Dependencies are managed with UV via a `pyproject.toml` file. The app runs on boot using systemd, and optionally, you can expose it securely via Cloudflare Tunnel (also boot-enabled).
+- `dogcam_stream.py`: Flask app and camera endpoints
+- `servo_control_rpigpio.py`: MG90S pan and tilt servo control
+- `templates/index.html`: main camera UI
+- `templates/login.html`: login screen
+- `ky004-control.py`: optional GPIO button power control
+- `service_startup/`: example systemd unit files
+- `PIN_DIAGRAM.md`: wiring reference
 
-## Prerequisites
-- [Raspberry Pi 3](https://www.amazon.com/Raspberry-Pi-Model-Board-Plus/dp/B0BNJPL4MW?sr=8-1) with [Raspberry Pi OS (64-bit recommended)](https://www.raspberrypi.com/software/operating-systems/).
-- [Picamera Module V3 (or compatible) connected and enabled](https://www.amazon.com/Arducam-Raspberry-Camera-Autofocus-15-22pin/dp/B0C9PYCV9S?sr=8-1).
-- [OSOYOO DHT22 (or standard DHT22) temperature/humidity sensor](https://www.amazon.com/Gowoops-Temperature-Humidity-Measurement-Raspberry/dp/B073F472JL?sr=8-1).
-- (OPTIONAL) A domain with DNS hosted (e.g., via AWS Route 53) for remote access—use a placeholder like `your-domain.com`.
-- Basic tools: Git, Python 3.12+.
+## Hardware
 
-## Hardware Setup
+- Raspberry Pi with Raspberry Pi OS
+- CSI camera module
+- 2 MG90S servos for pan and tilt
+- optional DHT22 sensor on `GPIO4`
+- optional KY-004 button
 
-### 1. Connect the Camera Module
-- Attach the Picamera V3 to the Raspberry Pi's CSI port.
-- Enable the camera: Run `sudo raspi-config`, navigate to Interface Options > Camera > Enable, then reboot.
-- Test: Run `libcamera-hello` in terminal—if you see a preview, it's working.
+See `PIN_DIAGRAM.md` for wiring.
 
-### 2. Connect the DHT22 Sensor
-- Wiring (using GPIO pins; power off Pi before connecting):
+## Manual Controls
 
-| Sensor Pin | Raspberry Pi Physical Pin | Function | Notes |
-|------------|---------------------------|----------|-------|
-| VCC | Pin 1 | 3.3V Power | Supplies power to the sensor. Although the manufacturer's tutorial suggests connecting to 5V (Pi Pin 2 or 4), using 3.3V is safer and recommended to prevent potential voltage mismatch that could damage the Pi's GPIO pins. The sensor operates fine at 3.3V. |
-| Data | Pin 7 | GPIO4 | The data signal pin. GPIO4 is commonly used in tutorials, but you can choose any available GPIO pin and adjust your code accordingly. |
-| GND | Pin 9 | Ground | Completes the circuit. Using Pin 9 to avoid conflicts with other components. |
+- Desktop:
+  - click and hold the arrow buttons
+  - use `↑ ↓ ← →`
+  - use `W A S D`
+- Mobile:
+  - drag up and down on the screen for tilt
+  - drag left and right on the screen for pan
 
-- Add a 4.7kΩ-10kΩ pull-up resistor between VCC and Data pins for signal stability.
-- Test: After software setup, run a simple script to verify readings (see Software Installation).
+## Environment
 
-### 3. Connect the Power Button (Optional - Hardware Shutdown/Wake)
-- **OPTIONAL**: Add a physical button for safe shutdown and wake-up control
-- **Product Used**: [Youliang KY-004 3-Pin Button Key Tactile Switch Sensor](https://www.amazon.co.jp/dp/B07TBKTGR3)
-- **Reference**: [KY-004 Key Switch Module Documentation](https://arduinomodules.info/ky-004-key-switch-module/)
-- **Why GPIO3?**: GPIO3 (Pin 5) is the only GPIO pin with hardware wake-up capability on Raspberry Pi
-- Wiring (power off Pi before connecting):
+Create a local `.env` in the project root on the Raspberry Pi. Do not commit it.
 
-| KY-004 Pin | Raspberry Pi Physical Pin | Function | Notes |
-|------------|---------------------------|----------|-------|
-| S (Signal/Left) | Pin 5 | GPIO3 | Signal pin - GPIO3 has special wake-up capability. Outputs HIGH when NOT pressed, LOW when pressed (inverted logic) |
-| Middle (VCC) | Pin 2 | 5V Power | Powers the button module (requires 5V, not 3.3V!) |
-| - (GND/Right) | Pin 6 | Ground | Completes the circuit |
+```env
+BASIC_AUTH_USERNAME=your_username
+BASIC_AUTH_PASSWORD=your_password
+SECRET_KEY=replace_me
+MAX_VIEWERS=3
+PORT=5000
+DOG_NAME=Kotaro
+```
 
-- **How It Works**:
-  - **When Pi is ON**: Press button to initiate safe shutdown (`sudo shutdown -h now`)
-  - **When Pi is OFF**: Press button to power on the Pi (GPIO3 hardware wake feature)
-  - No software configuration needed - works automatically with the systemd service
-- **Specifications**:
-  - Operating voltage: 3.3V-5V
-  - Tactile button rated for 100,000 cycles
-  - Built-in 10kΩ resistor
-- **Software Setup**: See "Power Button Service" section below
+## Raspberry Pi Setup
 
-## Software Installation
+### 1. System packages
 
-### 1. Raspberry Pi APT Installs
-- Update system and install required packages for GPIO, camera, and monitoring:
-  ```
-  sudo apt update && sudo apt upgrade -y
-  sudo apt install libgpiod2 libcamera-apps-lite python3-picamera2 htop -y
-  ```
+```bash
+sudo apt update
+sudo apt upgrade -y
+sudo apt install -y libgpiod2 libcamera-apps-lite python3-picamera2 python3-dev
+```
 
-### 2. Install UV (Package Manager)
-- UV is used for faster dependency management. Install globally:
-  ```
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  ```
-- If installed via pipx, path might be `~/.local/bin/uv`—add to PATH if needed: `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc`.
+If you use the DHT22:
 
-### 3. Set Up the Project
-- Clone the project repository:
-  ```
-  git clone https://github.com/gabrielAHN/dogo-cam-project.git
-  cd dogo-cam-project
-  ```
-- Create `.env` for secrets (do not commit to Git):
-  ```
-  BASIC_AUTH_USERNAME=your_username
-  BASIC_AUTH_PASSWORD=your_password
-  MAX_VIEWERS=3
-  PORT=5000
-  DOG_NAME=Dog  # Optional: customize the name shown in the web interface
-  ```
+```bash
+sudo apt install -y libgpiod-dev
+```
 
-### 4. Manage Dependencies with `pyproject.toml`
-- Create `pyproject.toml` in the project root:
-  ```
-  [project]
-  name = "dog-cam-stream"
-  version = "0.1.0"
-  requires-python = ">=3.12"
+### 2. Clone the repo
 
-  [tool.uv]
-  dependencies = [
-      "flask",
-      "flask-httpauth",
-      "picamera2",
-      "python-dotenv",
-      "adafruit-circuitpython-dht",
-      "adafruit-blinka",
-      "gunicorn",  # For production server
-  ]
-  ```
-- Sync dependencies (creates/manages venv):
-  ```
-  uv sync
-  ```
+```bash
+git clone <your-repo-url> dogo-cam
+cd dogo-cam
+```
 
-### 5. Application Code
-- Main file: `dogcam_stream.py` (Flask app with streaming, auth, sensor reads—code as per your setup).
-- Template: `templates/index.html` (HTMX for dynamic temp/humidity display).
-- Test locally: `uv run gunicorn --worker-class gthread --workers 1 --threads 4 --bind 0.0.0.0:5000 dogcam_stream:app`
-  - Access `http://your-pi-ip:5000` (e.g., `http://192.168.1.100:5000`), enter auth creds.
+### 3. Install `uv`
 
-## Setting Up on Boot (Systemd Service)
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
 
-### 1. Create the Service File
-- Edit `/etc/systemd/system/dog-stream.service` (use a generic name; sudo required):
-  ```
-  [Unit]
-  Description=Dog Stream Flask App
-  After=network.target
+Restart the shell or add `~/.local/bin` to `PATH` if needed.
 
-  [Service]
-  User=your-user
-  WorkingDirectory=/home/your-user/dogo-cam-project
-  EnvironmentFile=/home/your-user/dogo-cam-project/.env
-  ExecStart=/home/your-user/.local/bin/uv run gunicorn --worker-class gthread --workers 1 --threads 4 --bind 0.0.0.0:5000 dogcam_stream:app
-  Restart=always
-  RestartSec=10
-  LimitNOFILE=4096
-  OOMScoreAdjust=-1000
+### 4. Install Python dependencies
 
-  [Install]
-  WantedBy=multi-user.target
-  ```
-- Reload and enable:
-  ```
-  sudo systemctl daemon-reload
-  sudo systemctl enable --now dog-stream.service
-  ```
-- Check: `sudo systemctl status dog-stream.service`—should be active.
+```bash
+uv sync
+```
 
-### 2. Power Button Service (Required for Sleep-by-Default Mode)
-If you connected the KY-004 power button to GPIO3 (Pin 5):
+You can also use:
 
-**New Behavior**: The Pi now sleeps by default. Press button to wake and start services, press again to shutdown.
-See [BUTTON_BEHAVIOR.md](BUTTON_BEHAVIOR.md) for detailed documentation.
+```bash
+uv run python -m py_compile dogcam_stream.py servo_control_rpigpio.py
+```
 
-- Create the button script `/home/your-user/ky004-control.py`:
-  ```python
-  #!/usr/bin/env python3
-  import lgpio
-  import time
-  import os
+### 5. Run locally
 
-  BUTTON_PIN = 3
-  DEBOUNCE_TIME = 0.1
-  SHUTDOWN_STATE_FILE = "/tmp/shutdown_pending"
+```bash
+uv run gunicorn --worker-class gthread --workers 1 --threads 4 --bind 0.0.0.0:5000 dogcam_stream:app
+```
 
-  def main():
-      if os.path.exists(SHUTDOWN_STATE_FILE):
-          os.remove(SHUTDOWN_STATE_FILE)
+Open `http://<pi-ip>:5000`.
 
-      h = lgpio.gpiochip_open(0)
-      lgpio.gpio_claim_input(h, BUTTON_PIN, lgpio.SET_PULL_UP)
+## systemd
 
-      print(f"Power button monitoring on GPIO{BUTTON_PIN}")
+Example units are in `service_startup/`.
 
-      try:
-          while True:
-              if lgpio.gpio_read(h, BUTTON_PIN) == 0:
-                  time.sleep(DEBOUNCE_TIME)
-                  if lgpio.gpio_read(h, BUTTON_PIN) == 0:
-                      with open(SHUTDOWN_STATE_FILE, 'w') as f:
-                          f.write('1')
-                      time.sleep(2)
-                      lgpio.gpiochip_close(h)
-                      os.system("sudo shutdown -h now")
-                      break
-              time.sleep(0.2)
-      except KeyboardInterrupt:
-          print("\nStopped")
-      finally:
-          lgpio.gpiochip_close(h)
+### Flask app
 
-  if __name__ == "__main__":
-      main()
-  ```
+Copy `service_startup/dog-stream-flask.service` to `/etc/systemd/system/dog-stream.service`, then adjust:
 
-- Create systemd service `/etc/systemd/system/button-control.service`:
-  ```
-  [Unit]
-  Description=KY-004 Button Control (Stream Toggle & Shutdown)
-  After=multi-user.target
+- `User`
+- `WorkingDirectory`
+- `EnvironmentFile`
+- `ExecStart`
 
-  [Service]
-  Type=simple
-  User=your-user
-  WorkingDirectory=/home/your-user
-  ExecStart=/usr/bin/python3 /home/your-user/ky004-control.py
-  Restart=always
-  RestartSec=10
+Enable it:
 
-  [Install]
-  WantedBy=multi-user.target
-  ```
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now dog-stream.service
+sudo systemctl status dog-stream.service
+```
 
-- **Quick Deploy Method**: Use the deployment script to install everything:
-  ```bash
-  ./deploy_button_changes.sh
-  ```
+### Optional button service
 
-- **Manual Install**: Or install manually:
-  ```
-  sudo systemctl daemon-reload
-  sudo systemctl enable button-control.service
-  sudo systemctl disable dog-stream.service  # Prevent auto-start
-  sudo systemctl start button-control.service
-  ```
+If you use the KY-004 button:
 
-- **Test the new behavior**:
-  1. Press button once → dog-stream service starts (camera begins streaming)
-  2. Press button again → Pi shuts down safely
-  3. While off, press button → Pi wakes up (GPIO3 hardware feature)
-  4. Check logs: `sudo journalctl -u button-control.service -f`
+```bash
+sudo cp service_startup/button-control.service /etc/systemd/system/button-control.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now button-control.service
+```
 
-## Optional: Cloudflare Tunnel Setup for Remote Access
-Expose the local app securely to your domain (e.g., `your-domain.com`) without port forwarding. Cloudflare handles HTTPS and DNS (delegate nameservers from your hosted zone provider like AWS Route 53).
+Update the unit path if your project directory is different.
 
-### 1. Install Cloudflared
-- Download for ARM: `wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm -O cloudflared`
-- Make executable and move: `chmod +x cloudflared && sudo mv cloudflared /usr/local/bin/`
+### Optional Cloudflare Tunnel
 
-### 2. Authenticate and Create Tunnel
-- Log in: `cloudflared tunnel login`
-- Create: `cloudflared tunnel create dog-stream-tunnel`
-- Config file (`~/.cloudflared/config.yml`):
-  ```
-  tunnel: dog-stream-tunnel
-  credentials-file: /home/your-user/.cloudflared/<tunnel-uuid>.json
-  ingress:
-    - hostname: your-domain.com
-      service: http://localhost:5000
-    - service: http_status:404
-  ```
-- Run manually: `cloudflared tunnel run dog-stream-tunnel`
+Copy `service_startup/cloudflared-tunnel.service` after you have:
 
-### 3. DNS Setup
-- In Cloudflare Dashboard: Add site > Enter `your-domain.com` > Update nameservers in your hosted zone (e.g., AWS Route 53) to Cloudflare's.
-- Add CNAME: Name `@` (root), Target `<tunnel-uuid>.cfargotunnel.com`, Proxied (orange cloud).
+- installed `cloudflared`
+- created a tunnel
+- created `~/.cloudflared/config.yml`
 
-### 4. Boot Setup for Tunnel (Systemd Service)
-- Create `/etc/systemd/system/cloudflared.service`:
-  ```
-  [Unit]
-  Description=Cloudflare Tunnel for Dog Stream
-  After=network.target
+Then:
 
-  [Service]
-  User=your-user
-  ExecStart=/usr/local/bin/cloudflared tunnel --config /home/your-user/.cloudflared/config.yml run dog-stream-tunnel
-  Restart=always
-  RestartSec=10
+```bash
+sudo cp service_startup/cloudflared-tunnel.service /etc/systemd/system/cloudflared-tunnel.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now cloudflared-tunnel.service
+```
 
-  [Install]
-  WantedBy=multi-user.target
-  ```
-- Enable: `sudo systemctl enable --now cloudflared.service`
-- Check: `sudo systemctl status cloudflared.service`
+## Deploying Updates To The Pi
 
-## Using the Power Button
+On the Pi:
 
-The KY-004 button on GPIO3 (Pin 5) provides hardware power control:
+```bash
+cd ~/dogo-cam
+git pull
+uv sync
+sudo systemctl restart dog-stream.service
+```
 
-1. **Shutdown**: Press the button once
-   - Web interface shows "⚠️ Shutting Down..." for 2 seconds
-   - Pi safely shuts down
-2. **Wake Up**: Press the button again while Pi is off
-   - Pi powers back on (GPIO3 hardware wake feature)
-   - All services start automatically on boot
+## Notes
 
-### Testing the Button
-
-After completing the hardware and software setup:
-
-1. Access the web interface: `http://your-pi-ip:5000`
-2. Observe the stream status indicator in the top-left corner
-3. Press the physical button - you should see "⚠️ Shutting Down..." then the Pi shuts down
-4. Press the button again - Pi powers back on
-5. Check logs: `journalctl -u button-control.service -f`
-   - You should see "Button pressed - Setting shutdown state..." before shutdown
-
-## Troubleshooting
-- Camera not starting: Ensure enabled in `raspi-config`; test with `libcamera-hello`.
-- Sensor errors: Verify pull-up resistor; retry logic in code handles checksum issues.
-- Access issues: Check auth creds in `.env`; monitor logs with `journalctl -u dog-stream-flask.service`.
-- Performance: On RPi 3, lower video resolution if CPU/RAM high (edit code: `{"size": (320, 240)}`).
-- Button not working: Check wiring (S→Pin 5, Middle→Pin 2, GND→Pin 6); verify lgpio is available; check logs with `journalctl -u button-control.service -f`.
+- `.env` should stay only on the Pi or your local machine.
+- Servo positions are persisted in `/tmp/servo_positions.json`.
+- The camera stream is flipped because the camera mount is inverted.

--- a/dogcam_stream.py
+++ b/dogcam_stream.py
@@ -4,14 +4,13 @@ import time
 import threading
 import atexit
 import logging
-import board
+from datetime import timedelta
+
 import adafruit_dht
+import board
 from dotenv import load_dotenv
-from flask import Flask, Response, render_template, request
-from flask_httpauth import HTTPBasicAuth
-from picamera2 import Picamera2
-from picamera2.encoders import JpegEncoder
-from picamera2.outputs import FileOutput
+from flask import Flask, Response, jsonify, redirect, render_template, request, session, url_for
+from functools import wraps
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -19,9 +18,14 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 app = Flask(__name__)
-auth = HTTPBasicAuth()
-camera = Picamera2()
-viewer_semaphore = threading.Semaphore(int(os.getenv('MAX_VIEWERS', 3)))
+app.secret_key = os.getenv("SECRET_KEY", os.urandom(24).hex())
+app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=1)
+viewer_semaphore = threading.Semaphore(int(os.getenv("MAX_VIEWERS", 3)))
+
+camera = None
+camera_available = False
+camera_running = False
+camera_lock = threading.Lock()
 
 dht_device = None
 dht_lock = threading.Lock()
@@ -29,9 +33,18 @@ last_dht_read = 0
 cached_temp = None
 cached_humidity = None
 
-STREAM_STATE_FILE = '/tmp/stream_enabled'
-SHUTDOWN_STATE_FILE = '/tmp/shutdown_pending'
-stream_lock = threading.Lock()
+STREAM_STATE_FILE = "/tmp/stream_enabled"
+SHUTDOWN_STATE_FILE = "/tmp/shutdown_pending"
+
+try:
+    from servo_control_rpigpio import servo_controller
+
+    servo_available = True
+    logger.info("Servo control loaded")
+except Exception as e:
+    logger.error(f"Servo control not available: {e}")
+    servo_available = False
+    servo_controller = None
 
 
 class StreamingOutput(io.BufferedIOBase):
@@ -48,39 +61,73 @@ class StreamingOutput(io.BufferedIOBase):
 output = StreamingOutput()
 
 
-def get_stream_state():
-    """Read current stream state from file (managed by button daemon)"""
-    try:
-        with open(STREAM_STATE_FILE, 'r') as f:
-            return f.read().strip() == '1'
-    except:
-        return True  # Default to enabled if file doesn't exist
+def login_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if not session.get("logged_in"):
+            return redirect(url_for("login", next=request.url))
+        return f(*args, **kwargs)
+
+    return decorated_function
 
 
-def is_shutdown_pending():
-    """Check if shutdown is pending"""
+def init_camera():
+    global camera
+    global camera_available
+    global camera_running
+
+    if camera is not None:
+        return camera_available
+
     try:
-        with open(SHUTDOWN_STATE_FILE, 'r') as f:
-            return f.read().strip() == '1'
-    except:
+        from libcamera import Transform
+        from picamera2 import Picamera2
+        from picamera2.encoders import JpegEncoder
+        from picamera2.outputs import FileOutput
+
+        logger.info("Attempting to initialize camera")
+        camera = Picamera2()
+        config = camera.create_video_configuration(
+            main={"size": (640, 480)},
+            transform=Transform(hflip=True, vflip=True),
+        )
+        camera.configure(config)
+        camera.start_recording(JpegEncoder(), FileOutput(output))
+        camera_available = True
+        camera_running = True
+        logger.info("Camera initialized successfully")
+        return True
+    except Exception as e:
+        logger.error(f"Camera initialization failed: {e}")
+        camera_available = False
+        camera_running = False
         return False
 
 
-camera.configure(camera.create_video_configuration(main={"size": (640, 480)}))
-camera.start_recording(JpegEncoder(), FileOutput(output))
+def get_stream_state():
+    try:
+        with open(STREAM_STATE_FILE, "r") as f:
+            return f.read().strip() == "1"
+    except Exception:
+        return True
 
-camera_running = True
-camera_lock = threading.Lock()
+
+def is_shutdown_pending():
+    try:
+        with open(SHUTDOWN_STATE_FILE, "r") as f:
+            return f.read().strip() == "1"
+    except Exception:
+        return False
 
 
 def check_shutdown_and_stop_camera():
-    """Monitor for shutdown signal and stop camera before shutdown"""
     global camera_running
+
     while True:
         if is_shutdown_pending():
             with camera_lock:
-                if camera_running:
-                    logger.info("Shutdown pending - stopping camera...")
+                if camera_running and camera is not None:
+                    logger.info("Shutdown pending - stopping camera")
                     try:
                         camera.stop_recording()
                         camera_running = False
@@ -93,83 +140,114 @@ def check_shutdown_and_stop_camera():
 
 def cleanup():
     global camera_running
+
     with camera_lock:
-        if camera_running:
+        if camera_running and camera is not None:
             try:
                 camera.stop_recording()
                 camera_running = False
-            except:
+            except Exception:
                 pass
 
+    if servo_available and servo_controller:
+        servo_controller.cleanup()
 
-# Start shutdown monitor thread
+
+init_camera()
+
+if servo_available and servo_controller:
+    servo_controller.initialize()
+
 shutdown_monitor = threading.Thread(target=check_shutdown_and_stop_camera, daemon=True)
 shutdown_monitor.start()
 
 atexit.register(cleanup)
 
 
-@auth.verify_password
-def verify_password(username, password):
-    return username == os.getenv('BASIC_AUTH_USERNAME') and password == os.getenv('BASIC_AUTH_PASSWORD')
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    error = None
+
+    if request.method == "POST":
+        username = request.form.get("username")
+        password = request.form.get("password")
+
+        if username == os.getenv("BASIC_AUTH_USERNAME") and password == os.getenv("BASIC_AUTH_PASSWORD"):
+            session["logged_in"] = True
+            session.permanent = True
+            next_page = request.args.get("next")
+            if next_page:
+                return redirect(next_page)
+            return redirect(url_for("index"))
+        error = "Invalid username or password. Please try again."
+
+    return render_template("login.html", error=error)
 
 
 def gen():
+    if not camera_available:
+        yield b""
+        return
+
     while True:
         with output.condition:
             output.condition.wait()
             frame = output.frame
-        yield (b'--frame\r\n'
-               b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
+        yield b"--frame\r\n" b"Content-Type: image/jpeg\r\n\r\n" + frame + b"\r\n"
 
 
-@app.route('/')
-@auth.login_required
+@app.route("/")
+@login_required
 def index():
-    dog_name = os.getenv('DOG_NAME', 'Dog')
-    return render_template('index.html', dog_name=dog_name)
+    dog_name = os.getenv("DOG_NAME", "Dog")
+    return render_template(
+        "index.html",
+        dog_name=dog_name,
+        camera_available=camera_available,
+        servo_available=servo_available,
+    )
 
 
-@app.route('/video_feed')
-@auth.login_required
+@app.route("/video_feed")
+@login_required
 def video_feed():
     if not get_stream_state():
         return "Stream is currently disabled. Press the button to enable.", 503
-
+    if not camera_available:
+        return "Camera not available. Please check camera connection.", 503
     if not viewer_semaphore.acquire(blocking=False):
         return "Max viewers reached. Try again later.", 503
     try:
-        return Response(gen(), mimetype='multipart/x-mixed-replace; boundary=frame')
+        return Response(gen(), mimetype="multipart/x-mixed-replace; boundary=frame")
     finally:
         viewer_semaphore.release()
 
 
 def init_dht_sensor():
     global dht_device
+
     if dht_device is None:
         dht_device = adafruit_dht.DHT22(board.D4)
     return dht_device
 
 
-@app.route('/temp')
-@auth.login_required
+@app.route("/temp")
+@login_required
 def temp():
-    global last_dht_read, cached_temp, cached_humidity
+    global last_dht_read
+    global cached_temp
+    global cached_humidity
 
     current_time = time.time()
 
     with dht_lock:
-
         sensor = init_dht_sensor()
 
-
         if current_time - last_dht_read < 3.0 and cached_temp is not None:
-            temp_f = cached_temp * 9/5 + 32
+            temp_f = cached_temp * 9 / 5 + 32
             return f"Room Temp: {cached_temp:.2f}°C ({temp_f:.2f}°F) | Humidity: {cached_humidity:.1f}%"
 
-
-        max_retries = 5
-        for attempt in range(max_retries):
+        for attempt in range(5):
             try:
                 temperature = sensor.temperature
                 humidity = sensor.humidity
@@ -177,31 +255,116 @@ def temp():
                     cached_temp = temperature
                     cached_humidity = humidity
                     last_dht_read = current_time
-                    temp_f = temperature * 9/5 + 32
+                    temp_f = temperature * 9 / 5 + 32
                     return f"Room Temp: {temperature:.2f}°C ({temp_f:.2f}°F) | Humidity: {humidity:.1f}%"
             except (RuntimeError, OSError):
-                if attempt < max_retries - 1:
+                if attempt < 4:
                     time.sleep(2.5)
-                continue
-            except Exception as error:
-
+            except Exception as e:
                 if cached_temp is not None:
-                    temp_f = cached_temp * 9/5 + 32
+                    temp_f = cached_temp * 9 / 5 + 32
                     return f"Room Temp: {cached_temp:.2f}°C ({temp_f:.2f}°F) | Humidity: {cached_humidity:.1f}% (cached)"
-                return f"Error: {str(error)}"
-
+                return f"Error: {e}"
 
         if cached_temp is not None:
-            temp_f = cached_temp * 9/5 + 32
+            temp_f = cached_temp * 9 / 5 + 32
             return f"Room Temp: {cached_temp:.2f}°C ({temp_f:.2f}°F) | Humidity: {cached_humidity:.1f}% (cached)"
 
     return "Data unavailable. Retrying soon..."
 
 
-@app.route('/stream_status')
-@auth.login_required
+@app.route("/stream_status")
+@login_required
 def stream_status():
     if is_shutdown_pending():
         return "⚠️ Shutting Down..."
-    status = "🟢 Stream Active" if get_stream_state() else "🔴 Stream Paused"
-    return status
+    if not camera_available:
+        return "⚠️ Camera Not Connected"
+    return "🟢 Stream Active" if get_stream_state() else "🔴 Stream Paused"
+
+
+@app.route("/camera_status")
+@login_required
+def camera_status():
+    return {"available": camera_available}, 200 if camera_available else 503
+
+
+@app.route("/servo/move", methods=["POST"])
+@login_required
+def servo_move():
+    if not servo_available:
+        return jsonify({"error": "Servo control not available"}), 503
+
+    data = request.get_json()
+    axis = data.get("axis")
+    direction = data.get("direction")
+
+    if axis == "servo1":
+        success, angle, can_up, can_down = servo_controller.move_servo1(direction)
+        if success:
+            pos = servo_controller.get_position()
+            return jsonify(
+                {
+                    "success": True,
+                    "axis": "servo1",
+                    "angle": angle,
+                    "servo1": angle,
+                    "servo2": pos["servo2"],
+                    "can_servo1_up": can_up,
+                    "can_servo1_down": can_down,
+                    "can_servo2_left": pos["can_servo2_left"],
+                    "can_servo2_right": pos["can_servo2_right"],
+                }
+            )
+
+    if axis == "servo2":
+        success, angle, can_left, can_right = servo_controller.move_servo2(direction)
+        if success:
+            pos = servo_controller.get_position()
+            return jsonify(
+                {
+                    "success": True,
+                    "axis": "servo2",
+                    "angle": angle,
+                    "servo1": pos["servo1"],
+                    "servo2": angle,
+                    "can_servo1_up": pos["can_servo1_up"],
+                    "can_servo1_down": pos["can_servo1_down"],
+                    "can_servo2_left": can_left,
+                    "can_servo2_right": can_right,
+                }
+            )
+
+    return jsonify({"error": "Invalid request"}), 400
+
+
+@app.route("/servo/position")
+@login_required
+def servo_position():
+    if not servo_available:
+        return jsonify({"error": "Servo control not available"}), 503
+    return jsonify(servo_controller.get_position())
+
+
+@app.route("/servo/reset", methods=["POST"])
+@login_required
+def servo_reset():
+    if not servo_available:
+        return jsonify({"error": "Servo control not available"}), 503
+
+    success = servo_controller.reset_to_home()
+    if success:
+        pos = servo_controller.get_position()
+        return jsonify(
+            {
+                "success": True,
+                "servo1": pos["servo1"],
+                "servo2": pos["servo2"],
+                "can_servo1_up": pos["can_servo1_up"],
+                "can_servo1_down": pos["can_servo1_down"],
+                "can_servo2_left": pos["can_servo2_left"],
+                "can_servo2_right": pos["can_servo2_right"],
+            }
+        )
+
+    return jsonify({"error": "Failed to reset servos"}), 500

--- a/ky004-control.py
+++ b/ky004-control.py
@@ -1,64 +1,169 @@
 #!/usr/bin/env python3
 """
-KY-004 Button Control for Dogo-Cam
-Simple shutdown button - services auto-start on boot
+Toggle Switch Control - Dog Cam
+GPIO17 (Pin 11) + GND (Pin 9 or 6)
 
-Button behavior:
-- When Pi is on: Press to shutdown
-- When Pi is off: Press to wake via GPIO3 hardware feature
+Switch ON  (GPIO17 = 0, pulled to GND) -> start Flask then Cloudflare
+Switch OFF (GPIO17 = 1, floating)      -> stop Cloudflare then Flask
+
+LED: solid = website live, flickering = starting/stopped
 """
-import lgpio
-import time
-import os
-import logging
+import lgpio, time, os, subprocess, urllib.request, logging, threading
 
-BUTTON_PIN = 3
-DEBOUNCE_TIME = 0.1
-SHUTDOWN_STATE_FILE = "/tmp/shutdown_pending"
+SWITCH_PIN = 17
+STREAM_SVC = "dog-stream.service"
+CF_SVC     = "cloudflared-tunnel.service"
+URL        = "http://localhost:5000/login"
+LED_PATH   = "/sys/class/leds/PWR"
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
 
 
-def shutdown_system():
-    """Initiate system shutdown"""
-    logger.info("Button pressed - initiating system shutdown...")
-    with open(SHUTDOWN_STATE_FILE, "w") as f:
-        f.write("1")
-    time.sleep(2)  # Give Flask app time to detect shutdown and stop camera
-    os.system("sudo shutdown -h now")
+# --- LED ---
 
+def led_write(f, v):
+    os.system(f'echo {v} | sudo tee {LED_PATH}/{f} > /dev/null 2>&1')
+
+def led_on():
+    led_write('trigger', 'none')
+    led_write('brightness', 1)
+
+def led_off():
+    led_write('trigger', 'none')
+    led_write('brightness', 0)
+
+_flicker_stop = threading.Event()
+_flicker_thread = None
+
+def led_flicker():
+    global _flicker_thread
+    _flicker_stop.clear()
+    def _loop():
+        led_write('trigger', 'none')
+        s = 1
+        while not _flicker_stop.is_set():
+            led_write('brightness', s)
+            s ^= 1
+            time.sleep(0.3)
+    _flicker_thread = threading.Thread(target=_loop, daemon=True)
+    _flicker_thread.start()
+
+def led_stop_flicker():
+    _flicker_stop.set()
+    if _flicker_thread:
+        _flicker_thread.join(timeout=1)
+
+
+# --- Services ---
+
+def site_up():
+    try:
+        urllib.request.urlopen(URL, timeout=1)
+        return True
+    except:
+        return False
+
+def run(cmd):
+    return subprocess.run(cmd, capture_output=True, timeout=15).returncode == 0
+
+def start():
+    log.info("ON: starting Flask...")
+    led_flicker()
+    run(['sudo', 'systemctl', 'start', STREAM_SVC])
+
+    for i in range(60):
+        if site_up():
+            log.info(f"Flask ready ({i}s), starting Cloudflare...")
+            run(['sudo', 'systemctl', 'start', CF_SVC])
+            led_stop_flicker()
+            led_on()
+            log.info("Website live")
+            return
+        time.sleep(1)
+    log.error("Flask did not respond in 60s")
+
+SHUTDOWN_FILE = "/tmp/shutdown_pending"
+
+def stop():
+    log.info("OFF: signalling camera to stop...")
+    led_flicker()
+
+    # Signal the Flask app to stop the camera gracefully
+    try:
+        with open(SHUTDOWN_FILE, 'w') as f:
+            f.write('1')
+    except Exception as e:
+        log.error(f"Could not write shutdown file: {e}")
+
+    # Give the camera time to stop recording
+    for i in range(10):
+        time.sleep(0.5)
+        try:
+            with open(SHUTDOWN_FILE) as f:
+                if f.read().strip() == '1':
+                    continue  # still waiting
+        except:
+            break
+    time.sleep(1)  # small extra buffer after camera stops
+
+    log.info("Camera stopped, stopping services...")
+    run(['sudo', 'systemctl', 'stop', CF_SVC])
+    run(['sudo', 'systemctl', 'stop', STREAM_SVC])
+
+    # Clean up shutdown file
+    try:
+        os.remove(SHUTDOWN_FILE)
+    except:
+        pass
+
+    led_stop_flicker()
+    led_off()
+    log.info("Services stopped")
+
+
+# --- Main ---
 
 def main():
-    # Clean up shutdown state file on startup
-    if os.path.exists(SHUTDOWN_STATE_FILE):
-        os.remove(SHUTDOWN_STATE_FILE)
-
-    # Initialize GPIO
     h = lgpio.gpiochip_open(0)
-    lgpio.gpio_claim_input(h, BUTTON_PIN, lgpio.SET_PULL_UP)
+    lgpio.gpio_claim_input(h, SWITCH_PIN, lgpio.SET_PULL_UP)
 
-    logger.info(f"Power button monitoring on GPIO{BUTTON_PIN} - press to shutdown")
+    def read():
+        # Debounce: sample 3 times over 50ms, must all agree
+        vals = []
+        for _ in range(3):
+            vals.append(lgpio.gpio_read(h, SWITCH_PIN))
+            time.sleep(0.017)
+        return 0 if all(v == 0 for v in vals) else 1 if all(v == 1 for v in vals) else None
+
+    # Settle on initial state
+    state = None
+    while state is None:
+        state = read()
+
+    log.info(f"Switch is {'ON' if state == 0 else 'OFF'} on startup")
+
+    if state == 0:
+        start() if not site_up() else (led_on() or log.info("Site already up"))
+    else:
+        stop()
+
+    log.info("Monitoring GPIO17 for switch changes...")
 
     try:
         while True:
-            # Check for button press (reads 0 when pressed due to pull-up logic)
-            if lgpio.gpio_read(h, BUTTON_PIN) == 0:
-                time.sleep(DEBOUNCE_TIME)
-                if lgpio.gpio_read(h, BUTTON_PIN) == 0:  # Confirm press after debounce
-                    logger.info("Button pressed!")
-                    lgpio.gpiochip_close(h)
-                    shutdown_system()
-                    break
-            time.sleep(0.2)
+            new = read()
+            if new is not None and new != state:
+                state = new
+                if state == 0:
+                    start()
+                else:
+                    stop()
+            time.sleep(0.1)
     except KeyboardInterrupt:
-        logger.info("\nStopped by user")
+        log.info("Stopped")
     finally:
         lgpio.gpiochip_close(h)
-
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "dog-kotaro-cam"
+name = "dogo-cam"
 version = "0.1.0"
-description = "Add your description here"
+description = "Manual Raspberry Pi camera stream with pan and tilt servo controls"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/service_startup/button-control.service
+++ b/service_startup/button-control.service
@@ -5,8 +5,8 @@ After=multi-user.target
 [Service]
 Type=simple
 User=your-user
-WorkingDirectory=/home/your-user
-ExecStart=/usr/bin/python3 /home/your-user/ky004-control.py
+WorkingDirectory=/home/your-user/dogo-cam
+ExecStart=/usr/bin/python3 /home/your-user/dogo-cam/ky004-control.py
 Restart=always
 RestartSec=10
 

--- a/service_startup/dog-stream-flask.service
+++ b/service_startup/dog-stream-flask.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 User=your-user
-WorkingDirectory=/home/your-user/dogo-cam-project
-EnvironmentFile=/home/your-user/dogo-cam-project/.env
+WorkingDirectory=/home/your-user/dogo-cam
+EnvironmentFile=/home/your-user/dogo-cam/.env
 ExecStart=/home/your-user/.local/bin/uv run gunicorn --worker-class gthread --workers 1 --threads 4 --bind 0.0.0.0:5000 dogcam_stream:app
 Restart=always
 RestartSec=10

--- a/servo_control_rpigpio.py
+++ b/servo_control_rpigpio.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+MG90S Servo Control using RPi.GPIO - Based on MakersPortal approach
+Tower Pro MG90S servos work best with this PWM implementation
+"""
+import RPi.GPIO as GPIO
+import threading
+import time
+import json
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Servo configuration
+SERVO1_PIN = 18  # GPIO18 (Pin 12)
+SERVO2_PIN = 19  # GPIO19 (Pin 35)
+PWM_FREQUENCY = 50  # 50Hz for servo control
+STEP_SIZE = 5     # Degrees per step (larger steps for more visible tracking)
+
+# Servo1 (tilt) limits - prevent camera from tilting too far up
+SERVO1_MIN_TILT = 90  # Don't tilt higher than 90° (prevents excessive upward tilt during tracking)
+
+# MG90S duty cycle range (from MakersPortal calibration)
+# Standard 5-10% causes jitter with MG90S
+MIN_DUTY = 2.0   # 0° position
+MAX_DUTY = 12.0  # 180° position
+
+# State file for persistence across mode changes
+STATE_FILE = '/tmp/servo_positions.json'
+
+class ServoController:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.servo1_angle = 0  # Start at 0 degrees
+        self.servo2_angle = 0  # Start at 0 degrees
+        self.initialized = False
+        self.pwm1 = None
+        self.pwm2 = None
+
+        # Track last movement time for each servo independently
+        self.last_servo1_time = 0
+        self.last_servo2_time = 0
+        self.min_movement_interval = 0.02  # 20ms per servo - responsive manual control (~50 updates/sec max)
+
+    def angle_to_duty_cycle(self, angle):
+        """
+        Convert angle (0-180) to duty cycle percentage
+        MG90S calibrated range: 2-12% (not standard 5-10%)
+        Based on MakersPortal testing
+        """
+        # Linear interpolation from 2% to 12%
+        duty = MIN_DUTY + (angle / 180.0) * (MAX_DUTY - MIN_DUTY)
+        return duty
+
+    def load_positions(self):
+        """Load saved servo positions to maintain position across mode changes"""
+        try:
+            if os.path.exists(STATE_FILE):
+                with open(STATE_FILE, 'r') as f:
+                    state = json.load(f)
+                    self.servo1_angle = state.get('servo1', 90)
+                    self.servo2_angle = state.get('servo2', 90)
+                    logger.info(f"Loaded saved positions: Servo1={self.servo1_angle}°, Servo2={self.servo2_angle}°")
+            else:
+                # No saved state, use center position
+                self.servo1_angle = 90
+                self.servo2_angle = 90
+                logger.info(f"No saved positions, using defaults: Servo1=90°, Servo2=90°")
+        except Exception as e:
+            logger.error(f"Error loading servo positions: {e}")
+            self.servo1_angle = 90
+            self.servo2_angle = 90
+
+    def initialize(self):
+        """Initialize GPIO and PWM - servos only move on button clicks"""
+        with self.lock:
+            if self.initialized:
+                return True
+
+            try:
+                # Setup GPIO
+                GPIO.setmode(GPIO.BCM)
+                GPIO.setup(SERVO1_PIN, GPIO.OUT)
+                GPIO.setup(SERVO2_PIN, GPIO.OUT)
+
+                # Create PWM instances
+                self.pwm1 = GPIO.PWM(SERVO1_PIN, PWM_FREQUENCY)
+                self.pwm2 = GPIO.PWM(SERVO2_PIN, PWM_FREQUENCY)
+
+                # Start PWM at 0% duty cycle (servos don't move)
+                self.pwm1.start(0)
+                self.pwm2.start(0)
+
+                # Load saved positions (maintains position across mode changes)
+                self.load_positions()
+
+                self.initialized = True
+                logger.info(f"Servos initialized with RPi.GPIO")
+                logger.info(f"Servo1 (tilt): {SERVO1_MIN_TILT}°-180°, Servo2 (pan): 0°-180°")
+                logger.info(f"Using MG90S calibrated duty cycle: {MIN_DUTY}%-{MAX_DUTY}%")
+                return True
+            except Exception as e:
+                logger.error(f"Error initializing servos: {e}")
+                return False
+
+    def _set_servo_position(self, pwm, angle, servo_name):
+        """
+        Set servo position using MakersPortal approach
+        Key: Set duty cycle, wait briefly, then set to 0 to reduce jitter
+        """
+        duty = self.angle_to_duty_cycle(angle)
+
+        # Send PWM signal
+        pwm.ChangeDutyCycle(duty)
+        logger.info(f"{servo_name} set to {angle}° (duty: {duty:.2f}%)")
+
+        # Wait for servo to reach position (minimal delay for fast tracking)
+        time.sleep(0.03)
+
+        # CRITICAL: Set duty to 0 to reduce jitter (MakersPortal technique)
+        pwm.ChangeDutyCycle(0)
+        logger.info(f"{servo_name} PWM stopped - position locked")
+
+    def move_servo1_smooth(self, direction, steps=2):
+        """
+        Move Servo 1 multiple steps smoothly (for manual control)
+        direction: 'up' or 'down'
+        steps: number of steps to move (default 2 for smooth button press feel)
+        Returns: (success, new_angle, can_go_up, can_go_down)
+        """
+        success = False
+        for i in range(steps):
+            result = self.move_servo1(direction)
+            if result[0]:  # If movement was successful
+                success = True
+                if i < steps - 1:  # Don't sleep on last step
+                    time.sleep(0.08)  # Small delay between steps for smoothness
+            else:
+                break  # Stop if rate limited
+
+        # Return the final state
+        return self.move_servo1(direction) if not success else result
+
+    def move_servo1(self, direction):
+        """
+        Move Servo 1 up or down (single step)
+        direction: 'up' or 'down'
+        Returns: (success, new_angle, can_go_up, can_go_down)
+        """
+        with self.lock:
+            if not self.initialized and not self.initialize():
+                return False, self.servo1_angle, True, True
+
+            # Rate limiting - prevent movements that are too rapid (per servo)
+            current_time = time.time()
+            time_since_last_move = current_time - self.last_servo1_time
+            if time_since_last_move < self.min_movement_interval:
+                logger.info(f"Servo1 movement too fast - waiting {self.min_movement_interval - time_since_last_move:.2f}s")
+                return False, self.servo1_angle, True, True
+
+            old_angle = self.servo1_angle
+
+            if direction == 'up':
+                new_angle = max(SERVO1_MIN_TILT, self.servo1_angle - STEP_SIZE)  # Don't tilt higher than limit
+            elif direction == 'down':
+                new_angle = min(180, self.servo1_angle + STEP_SIZE)  # Clamp to 180° maximum
+            else:
+                return False, self.servo1_angle, self.servo1_angle > SERVO1_MIN_TILT, self.servo1_angle < 180
+
+            logger.info(f"Servo1 {direction}: {old_angle}° → {new_angle}°")
+
+            # Only move if angle changed
+            if new_angle != old_angle:
+                self._set_servo_position(self.pwm1, new_angle, "Servo1")
+                self.servo1_angle = new_angle
+                self.last_servo1_time = time.time()  # Update servo1 timestamp
+                self.save_positions()
+
+            # Check if can continue in each direction
+            can_go_up = self.servo1_angle > SERVO1_MIN_TILT
+            can_go_down = self.servo1_angle < 180
+
+            return True, self.servo1_angle, can_go_up, can_go_down
+
+    def move_servo2_smooth(self, direction, steps=2):
+        """
+        Move Servo 2 multiple steps smoothly (for manual control)
+        direction: 'left' or 'right'
+        steps: number of steps to move (default 2 for smooth button press feel)
+        Returns: (success, new_angle, can_go_left, can_go_right)
+        """
+        success = False
+        for i in range(steps):
+            result = self.move_servo2(direction)
+            if result[0]:  # If movement was successful
+                success = True
+                if i < steps - 1:  # Don't sleep on last step
+                    time.sleep(0.08)  # Small delay between steps for smoothness
+            else:
+                break  # Stop if rate limited
+
+        # Return the final state
+        return self.move_servo2(direction) if not success else result
+
+    def move_servo2(self, direction):
+        """
+        Move Servo 2 left or right (single step)
+        direction: 'left' or 'right'
+        Returns: (success, new_angle, can_go_left, can_go_right)
+        """
+        with self.lock:
+            if not self.initialized and not self.initialize():
+                return False, self.servo2_angle, True, True
+
+            # Rate limiting - prevent movements that are too rapid (per servo)
+            current_time = time.time()
+            time_since_last_move = current_time - self.last_servo2_time
+            if time_since_last_move < self.min_movement_interval:
+                logger.info(f"Servo2 movement too fast - waiting {self.min_movement_interval - time_since_last_move:.2f}s")
+                return False, self.servo2_angle, True, True
+
+            old_angle = self.servo2_angle
+
+            if direction == 'left':
+                new_angle = max(0, self.servo2_angle - STEP_SIZE)  # Clamp to 0° minimum
+            elif direction == 'right':
+                new_angle = min(180, self.servo2_angle + STEP_SIZE)  # Clamp to 180° maximum
+            else:
+                return False, self.servo2_angle, self.servo2_angle > 0, self.servo2_angle < 180
+
+            logger.info(f"Servo2 {direction}: {old_angle}° → {new_angle}°")
+
+            # Only move if angle changed
+            if new_angle != old_angle:
+                self._set_servo_position(self.pwm2, new_angle, "Servo2")
+                self.servo2_angle = new_angle
+                self.last_servo2_time = time.time()  # Update servo2 timestamp
+                self.save_positions()
+
+            # Check if can continue in each direction
+            can_go_left = self.servo2_angle > 0
+            can_go_right = self.servo2_angle < 180
+
+            return True, self.servo2_angle, can_go_left, can_go_right
+
+    def set_servo1_angle(self, angle):
+        """Set servo1 to exact angle — used by PID controller"""
+        with self.lock:
+            if not self.initialized and not self.initialize():
+                return False
+            angle = float(max(SERVO1_MIN_TILT, min(180, angle)))
+            self._set_servo_position(self.pwm1, angle, "Servo1")
+            self.servo1_angle = angle
+            self.last_servo1_time = time.time()
+            self.save_positions()
+            return True
+
+    def set_servo2_angle(self, angle):
+        """Set servo2 to exact angle — used by PID controller"""
+        with self.lock:
+            if not self.initialized and not self.initialize():
+                return False
+            angle = float(max(0, min(180, angle)))
+            self._set_servo_position(self.pwm2, angle, "Servo2")
+            self.servo2_angle = angle
+            self.last_servo2_time = time.time()
+            self.save_positions()
+            return True
+
+    def reset_to_home(self):
+        """Reset both servos to center position (90°, 90°)"""
+        with self.lock:
+            if not self.initialized and not self.initialize():
+                return False
+
+            logger.info(f"Resetting servos: Servo1={self.servo1_angle}° → 90°, Servo2={self.servo2_angle}° → 90°")
+
+            # Set both servos to center position
+            self._set_servo_position(self.pwm1, 90, "Servo1")
+            time.sleep(0.2)  # Small delay between servos
+            self._set_servo_position(self.pwm2, 90, "Servo2")
+
+            self.servo1_angle = 90
+            self.servo2_angle = 90
+
+            self.save_positions()
+            logger.info(f"Reset complete: Servo1=90°, Servo2=90°")
+            return True
+
+    def get_position(self):
+        """Get current servo positions and available movements"""
+        with self.lock:
+            return {
+                'servo1': self.servo1_angle,
+                'servo2': self.servo2_angle,
+                'can_servo1_up': self.servo1_angle > SERVO1_MIN_TILT,
+                'can_servo1_down': self.servo1_angle < 180,
+                'can_servo2_left': self.servo2_angle > 0,
+                'can_servo2_right': self.servo2_angle < 180
+            }
+
+    def save_positions(self):
+        """Save current positions to maintain across mode changes"""
+        try:
+            state = {
+                'servo1': self.servo1_angle,
+                'servo2': self.servo2_angle
+            }
+            with open(STATE_FILE, 'w') as f:
+                json.dump(state, f)
+        except Exception as e:
+            logger.error(f"Error saving servo positions: {e}")
+
+    def cleanup(self):
+        """Clean up GPIO resources"""
+        with self.lock:
+            if self.initialized:
+                try:
+                    # Save positions before cleanup
+                    self.save_positions()
+                    # Stop PWM
+                    if self.pwm1:
+                        self.pwm1.stop()
+                    if self.pwm2:
+                        self.pwm2.stop()
+                    # Clean up GPIO
+                    GPIO.cleanup([SERVO1_PIN, SERVO2_PIN])
+                    logger.info("Servos cleaned up, positions saved")
+                except:
+                    pass
+                self.initialized = False
+
+# Global servo controller instance
+servo_controller = ServoController()

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,6 +59,8 @@
             font-family: 'Roboto', sans-serif;
         }
 
+        /* Servo status CSS removed */
+
         #stream-status {
             color: #fff;
             position: absolute;
@@ -98,6 +100,233 @@
             transform: scale(0.95);
         }
 
+        /* Settings Button */
+        #settings-btn {
+            position: absolute;
+            top: 20px;
+            right: 90px;
+            z-index: 11;
+            background-color: rgba(0, 0, 0, 0.6);
+            color: #fff;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            border-radius: 8px;
+            padding: 12px 16px;
+            font-size: 24px;
+            cursor: pointer;
+            font-family: 'Roboto', sans-serif;
+            transition: all 0.3s ease;
+            -webkit-tap-highlight-color: transparent;
+            display: {% if servo_available %}block{% else %}none{% endif %};
+        }
+
+        #settings-btn:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            border-color: rgba(255, 255, 255, 0.6);
+        }
+
+        #settings-btn:active {
+            transform: scale(0.95);
+        }
+
+        /* Settings Modal */
+        #servo-controls-modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.85);
+            z-index: 100;
+            align-items: center;
+            justify-content: center;
+            overflow-y: auto;
+        }
+
+        #servo-controls-modal.active {
+            display: flex;
+        }
+
+        #servo-controls {
+            background-color: rgba(20, 20, 20, 0.95);
+            border-radius: 16px;
+            padding: 25px;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            max-height: 90vh;
+            overflow-y: auto;
+            max-width: 400px;
+            width: 90%;
+        }
+
+        .modal-header {
+            color: #fff;
+            font-family: 'Roboto', sans-serif;
+            font-size: 22px;
+            text-align: center;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+
+        .close-modal {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            color: #fff;
+            font-size: 36px;
+            cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        .servo-panel {
+            background-color: rgba(0, 0, 0, 0.7);
+            border-radius: 12px;
+            padding: 15px;
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .servo-panel.visible {
+            display: flex;
+        }
+
+        .controls-hint {
+            background-color: rgba(76, 175, 80, 0.2);
+            border: 1px solid rgba(76, 175, 80, 0.5);
+            border-radius: 8px;
+            padding: 12px;
+            color: #fff;
+            font-size: 13px;
+            text-align: center;
+            margin-top: 10px;
+        }
+
+        .keyboard-hint {
+            font-family: monospace;
+            background-color: rgba(0, 0, 0, 0.5);
+            padding: 2px 6px;
+            border-radius: 3px;
+            margin: 0 2px;
+        }
+
+        .servo-label {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            color: #fff;
+            font-family: 'Roboto', sans-serif;
+            font-size: 13px;
+            opacity: 0.8;
+            margin-bottom: 6px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+        }
+
+        .servo-value {
+            color: #4CAF50;
+            font-family: 'Roboto', monospace;
+            font-size: 17px;
+            font-weight: bold;
+            opacity: 1;
+        }
+
+        .servo-buttons {
+            display: grid;
+            gap: 8px;
+        }
+
+        .tilt-buttons {
+            grid-template-columns: 60px;
+            grid-template-rows: repeat(2, 60px);
+        }
+
+        .pan-buttons {
+            grid-template-columns: repeat(2, 60px);
+            grid-template-rows: 60px;
+        }
+
+        .servo-btn {
+            background-color: rgba(255, 255, 255, 0.15);
+            color: #fff;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            border-radius: 8px;
+            font-size: 28px;
+            cursor: pointer;
+            font-family: 'Roboto', sans-serif;
+            transition: all 0.2s ease;
+            -webkit-tap-highlight-color: transparent;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            touch-action: manipulation;
+            user-select: none;
+            padding: 0;
+        }
+
+        .servo-btn:active:not(:disabled) {
+            transform: scale(0.9);
+            background-color: rgba(255, 255, 255, 0.3);
+        }
+
+        .servo-btn:disabled {
+            opacity: 0.3;
+            cursor: not-allowed;
+            border-color: rgba(255, 255, 255, 0.1);
+        }
+
+        .reset-btn {
+            background-color: rgba(255, 165, 0, 0.2);
+            color: #fff;
+            border: 2px solid rgba(255, 165, 0, 0.5);
+            border-radius: 8px;
+            font-size: 15px;
+            cursor: pointer;
+            font-family: 'Roboto', sans-serif;
+            transition: all 0.2s ease;
+            -webkit-tap-highlight-color: transparent;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            touch-action: manipulation;
+            user-select: none;
+            padding: 12px 16px;
+            width: 100%;
+            font-weight: bold;
+        }
+
+        .reset-btn:active {
+            transform: scale(0.95);
+            background-color: rgba(255, 165, 0, 0.4);
+            border-color: rgba(255, 165, 0, 0.8);
+        }
+
+        .camera-unavailable {
+            color: #fff;
+            font-family: 'Roboto', sans-serif;
+            text-align: center;
+            font-size: 24px;
+            background-color: rgba(255, 0, 0, 0.3);
+            padding: 40px;
+            border-radius: 12px;
+            border: 2px solid rgba(255, 0, 0, 0.6);
+            max-width: 500px;
+        }
+
+        .camera-unavailable h2 {
+            font-size: 48px;
+            margin: 0 0 20px 0;
+        }
+
+        .camera-unavailable p {
+            margin: 10px 0;
+            font-size: 18px;
+        }
+
         body:fullscreen #fullscreen-btn,
         body:-webkit-full-screen #fullscreen-btn,
         body:-moz-full-screen #fullscreen-btn,
@@ -111,6 +340,7 @@
         body:-ms-fullscreen #fullscreen-btn:hover {
             opacity: 1;
         }
+
         body.mobile-fullscreen {
             position: fixed;
             top: 0;
@@ -123,7 +353,8 @@
 
         body.mobile-fullscreen h1,
         body.mobile-fullscreen #temp,
-        body.mobile-fullscreen #stream-status {
+        body.mobile-fullscreen #stream-status,
+        body.mobile-fullscreen #servo-controls {
             opacity: 0;
             pointer-events: none;
             transition: opacity 0.3s;
@@ -136,6 +367,28 @@
         body.mobile-fullscreen #fullscreen-btn:active {
             opacity: 1;
         }
+
+        /* Mobile responsive adjustments */
+        @media (max-width: 768px) {
+            #servo-controls {
+                bottom: 60px;
+                right: 10px;
+            }
+
+            .servo-btn {
+                font-size: 20px;
+            }
+
+            .tilt-buttons {
+                grid-template-columns: 50px;
+                grid-template-rows: repeat(2, 50px);
+            }
+
+            .pan-buttons {
+                grid-template-columns: repeat(2, 50px);
+                grid-template-rows: 50px;
+            }
+        }
     </style>
 </head>
 
@@ -145,15 +398,64 @@
         <div id="stream-status" hx-get="/stream_status" hx-trigger="load, every 2s" hx-swap="innerHTML">
             Checking status...
         </div>
+        <!-- Settings Button -->
+        <button id="settings-btn" title="Camera Settings" onclick="toggleServoModal()">⚙</button>
+
         <button id="fullscreen-btn" title="Toggle Fullscreen">⛶</button>
+
+        <!-- Settings Modal -->
+        {% if servo_available %}
+        <div id="servo-controls-modal">
+            <span class="close-modal" onclick="toggleServoModal()">×</span>
+            <div id="servo-controls">
+                <div class="modal-header">⚙ Camera Controls</div>
+                <!-- Manual Control Panel -->
+                <div id="panel-manual" class="servo-panel visible">
+                    <div class="servo-label"><span>Tilt</span><span class="servo-value" id="servo1-angle">--</span></div>
+                    <div class="servo-buttons tilt-buttons">
+                        <button id="btn-up" class="servo-btn">▲</button>
+                        <button id="btn-down" class="servo-btn">▼</button>
+                    </div>
+
+                    <div class="servo-label" style="margin-top: 15px;"><span>Pan</span><span class="servo-value" id="servo2-angle">--</span></div>
+                    <div class="servo-buttons pan-buttons">
+                        <button id="btn-left" class="servo-btn">◀</button>
+                        <button id="btn-right" class="servo-btn">▶</button>
+                    </div>
+
+                    <button id="btn-reset" class="reset-btn" onclick="resetServos()" style="margin-top: 15px;">🏠 Home</button>
+
+                    <div class="controls-hint">
+                        <div><strong>Keyboard:</strong> <span class="keyboard-hint">↑↓←→</span> or <span class="keyboard-hint">WASD</span></div>
+                        <div style="margin-top: 5px;"><strong>Touch:</strong> Drag on screen</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
+        {% if camera_available %}
         <img src="{{ url_for('video_feed') }}" alt="Live Dog Cam">
+        {% else %}
+        <div class="camera-unavailable">
+            <h2>📷</h2>
+            <p><strong>Camera Not Available</strong></p>
+            <p>Please check camera connection</p>
+            <p style="font-size: 14px; margin-top: 20px; opacity: 0.7;">Temperature sensor still available below</p>
+        </div>
+        {% endif %}
+
+        <!-- Servo Status Display - Removed -->
+
         <div id="temp" hx-get="/temp" hx-trigger="load, every 10s" hx-swap="innerHTML">
             Loading temperature...
         </div>
     </div>
 
     <script>
+        console.log('=== SCRIPT STARTED ===');
         const fullscreenBtn = document.getElementById('fullscreen-btn');
+        console.log('Fullscreen button:', fullscreenBtn);
         const container = document.body;
         const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
         let mobileFullscreen = false;
@@ -227,6 +529,339 @@
         function updateFullscreenButton() {
             fullscreenBtn.textContent = isFullscreen() ? '✕' : '⛶';
         }
+
+        let currentMode = 'manual';
+
+        function setManualPanel() {
+            const panel = document.getElementById('panel-manual');
+            if (panel) {
+                panel.classList.add('visible');
+            }
+        }
+
+        function toggleServoModal() {
+            console.log('toggleServoModal called');
+            const modal = document.getElementById('servo-controls-modal');
+            if (!modal) {
+                console.error('Modal not found!');
+                return;
+            }
+
+            modal.classList.toggle('active');
+            setManualPanel();
+        }
+
+        // Close modal when clicking outside the controls
+        document.addEventListener('click', function(event) {
+            const modal = document.getElementById('servo-controls-modal');
+            if (!modal) return; // Modal doesn't exist if servo not available
+
+            const controls = document.getElementById('servo-controls');
+            const settingsBtn = document.getElementById('settings-btn');
+
+            if (modal.classList.contains('active') &&
+                !controls.contains(event.target) &&
+                !settingsBtn.contains(event.target) &&
+                event.target.className !== 'close-modal') {
+                toggleServoModal();
+            }
+        });
+
+        {% if servo_available %}
+
+        let lastMoveTime = 0;
+        const MOVE_THROTTLE_MS = 150;
+
+        async function moveServo(axis, direction) {
+            const now = Date.now();
+            if (now - lastMoveTime < MOVE_THROTTLE_MS) return;
+            lastMoveTime = now;
+
+            try {
+                const response = await fetch('/servo/move', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ axis, direction })
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    updateButtonStates(data);
+                } else {
+                    console.error('Move failed:', response.status);
+                }
+            } catch (error) {
+                console.error('Error moving servo:', error);
+            }
+        }
+
+        let holdInterval = null;
+
+        function startHold(axis, direction) {
+            if (holdInterval) stopHold();
+            moveServo(axis, direction);
+            holdInterval = setInterval(() => {
+                moveServo(axis, direction);
+            }, MOVE_THROTTLE_MS);
+        }
+
+        function stopHold() {
+            if (holdInterval) {
+                clearInterval(holdInterval);
+                holdInterval = null;
+            }
+        }
+
+        function setupServoButtons() {
+            const buttons = [
+                { id: 'btn-up', axis: 'servo1', direction: 'up' },
+                { id: 'btn-down', axis: 'servo1', direction: 'down' },
+                { id: 'btn-left', axis: 'servo2', direction: 'left' },
+                { id: 'btn-right', axis: 'servo2', direction: 'right' }
+            ];
+
+            buttons.forEach(({ id, axis, direction }) => {
+                const btn = document.getElementById(id);
+                if (!btn) return;
+
+                // Mouse/Touch hold-to-move handlers
+                btn.addEventListener('mousedown', (e) => {
+                    e.preventDefault();
+                    if (!btn.disabled) {
+                        startHold(axis, direction);
+                    }
+                });
+
+                btn.addEventListener('mouseup', (e) => {
+                    e.preventDefault();
+                    stopHold();
+                });
+
+                btn.addEventListener('mouseleave', (e) => {
+                    stopHold();
+                });
+
+                // Touch hold-to-move handlers
+                btn.addEventListener('touchstart', (e) => {
+                    e.preventDefault();
+                    if (!btn.disabled) {
+                        startHold(axis, direction);
+                    }
+                });
+
+                btn.addEventListener('touchend', (e) => {
+                    e.preventDefault();
+                    stopHold();
+                });
+
+                btn.addEventListener('touchcancel', (e) => {
+                    stopHold();
+                });
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            setManualPanel();
+            setupServoButtons();
+            loadServoState();
+        });
+
+        // Keyboard Controls (Arrow keys and WASD) - Hold to move
+        let keyboardEnabled = false;
+        let pressedKeys = new Set();
+
+        function handleKeyDown(e) {
+            if (!keyboardEnabled || currentMode !== 'manual') return;
+            if (document.activeElement.tagName === 'INPUT') return; // Don't interfere with inputs
+
+            const key = e.key.toLowerCase();
+
+            // Ignore if already holding this key (prevents key repeat)
+            if (pressedKeys.has(key)) return;
+
+            let axis, direction;
+
+            switch(key) {
+                // Arrow keys
+                case 'arrowup':
+                case 'w':
+                    axis = 'servo1';
+                    direction = 'up';
+                    break;
+                case 'arrowdown':
+                case 's':
+                    axis = 'servo1';
+                    direction = 'down';
+                    break;
+                case 'arrowleft':
+                case 'a':
+                    axis = 'servo2';
+                    direction = 'left';
+                    break;
+                case 'arrowright':
+                case 'd':
+                    axis = 'servo2';
+                    direction = 'right';
+                    break;
+                default:
+                    return;
+            }
+
+            e.preventDefault();
+            pressedKeys.add(key);
+            startHold(axis, direction);
+        }
+
+        function handleKeyUp(e) {
+            const key = e.key.toLowerCase();
+            if (pressedKeys.has(key)) {
+                pressedKeys.delete(key);
+                stopHold();
+            }
+        }
+
+        document.addEventListener('keydown', handleKeyDown);
+        document.addEventListener('keyup', handleKeyUp);
+
+        // Stop movement when window loses focus
+        window.addEventListener('blur', () => {
+            pressedKeys.clear();
+            stopHold();
+        });
+
+        keyboardEnabled = true;
+
+        let touchLastX = 0;
+        let touchLastY = 0;
+        const touchMoveThreshold = 28;
+
+        document.addEventListener('touchstart', (e) => {
+            if (currentMode !== 'manual' || e.touches.length !== 1) return;
+            touchLastX = e.touches[0].clientX;
+            touchLastY = e.touches[0].clientY;
+        }, { passive: true });
+
+        document.addEventListener('touchmove', (e) => {
+            if (currentMode !== 'manual' || e.touches.length !== 1) return;
+
+            const touchX = e.touches[0].clientX;
+            const touchY = e.touches[0].clientY;
+            const deltaX = touchX - touchLastX;
+            const deltaY = touchY - touchLastY;
+
+            if (Math.abs(deltaX) < touchMoveThreshold && Math.abs(deltaY) < touchMoveThreshold) {
+                return;
+            }
+
+            e.preventDefault();
+
+            if (Math.abs(deltaY) >= Math.abs(deltaX)) {
+                moveServo('servo1', deltaY > 0 ? 'down' : 'up');
+            } else {
+                moveServo('servo2', deltaX > 0 ? 'right' : 'left');
+            }
+
+            touchLastX = touchX;
+            touchLastY = touchY;
+        }, { passive: false });
+
+        document.addEventListener('touchend', () => {
+            touchLastX = 0;
+            touchLastY = 0;
+        }, { passive: true });
+
+        async function resetServos() {
+            const btn = document.getElementById('btn-reset');
+
+            try {
+                btn.disabled = true;
+                btn.style.opacity = '0.5';
+                btn.textContent = '⏳ Resetting';
+
+                const response = await fetch('/servo/reset', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    updateButtonStates(data);
+                    console.log('Reset complete:', data);
+                } else {
+                    console.error('Reset failed:', response.status);
+                }
+            } catch (error) {
+                console.error('Error resetting servos:', error);
+            } finally {
+                btn.disabled = false;
+                btn.style.opacity = '1';
+                btn.textContent = '🏠 Home';
+
+            }
+        }
+
+        function formatServoValue(value) {
+            const rounded = Math.round(Number(value) * 10) / 10;
+            return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+        }
+
+        function updateButtonStates(data) {
+            if (data.can_servo1_up !== undefined) {
+                document.getElementById('btn-up').disabled = !data.can_servo1_up;
+            }
+            if (data.can_servo1_down !== undefined) {
+                document.getElementById('btn-down').disabled = !data.can_servo1_down;
+            }
+
+            if (data.can_servo2_left !== undefined) {
+                document.getElementById('btn-left').disabled = !data.can_servo2_left;
+            }
+            if (data.can_servo2_right !== undefined) {
+                document.getElementById('btn-right').disabled = !data.can_servo2_right;
+            }
+
+            if (data.servo1 !== undefined) {
+                const modalDisplay = document.getElementById('servo1-angle');
+                if (modalDisplay) {
+                    modalDisplay.textContent = formatServoValue(data.servo1);
+                }
+            }
+
+            if (data.servo2 !== undefined) {
+                const modalDisplay = document.getElementById('servo2-angle');
+                if (modalDisplay) {
+                    modalDisplay.textContent = formatServoValue(data.servo2);
+                }
+            }
+        }
+
+        // Load initial servo state and update displays
+        async function loadServoState() {
+            console.log('=== loadServoState called ===');
+            try {
+                const response = await fetch('/servo/position');
+                console.log('Servo position response:', response.status);
+                if (response.ok) {
+                    const data = await response.json();
+                    console.log('Servo position data:', data);
+
+                    // Servo displays removed
+
+                    // Update button states
+                    updateButtonStates(data);
+                } else {
+                    console.error('Failed to fetch servo position:', response.status);
+                }
+            } catch (error) {
+                console.error('Error loading servo state:', error);
+            }
+        }
+
+        // Auto-refresh servo positions every 2 seconds to detect manual movements
+        console.log('=== Setting up auto-refresh interval ===');
+        setInterval(loadServoState, 2000);
+        {% endif %}
+
     </script>
 </body>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - Dog Cam</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Roboto', sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+
+        .login-container {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            padding: 50px 40px;
+            max-width: 400px;
+            width: 100%;
+        }
+
+        .login-header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        .login-header h1 {
+            color: #333;
+            font-size: 32px;
+            margin-bottom: 10px;
+        }
+
+        .login-header p {
+            color: #666;
+            font-size: 16px;
+        }
+
+        .login-icon {
+            font-size: 64px;
+            margin-bottom: 20px;
+        }
+
+        .form-group {
+            margin-bottom: 25px;
+        }
+
+        .form-group label {
+            display: block;
+            color: #333;
+            font-weight: 500;
+            margin-bottom: 8px;
+            font-size: 14px;
+        }
+
+        .form-group input {
+            width: 100%;
+            padding: 15px;
+            border: 2px solid #e0e0e0;
+            border-radius: 10px;
+            font-size: 16px;
+            transition: all 0.3s;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .form-group input:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        }
+
+        .login-button {
+            width: 100%;
+            padding: 16px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            border-radius: 10px;
+            font-size: 18px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s, box-shadow 0.2s;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .login-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 20px rgba(102, 126, 234, 0.3);
+        }
+
+        .login-button:active {
+            transform: translateY(0);
+        }
+
+        .error-message {
+            background: #fee;
+            color: #c33;
+            padding: 12px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            border-left: 4px solid #c33;
+            font-size: 14px;
+        }
+
+        .remember-me {
+            display: flex;
+            align-items: center;
+            margin-bottom: 25px;
+        }
+
+        .remember-me input[type="checkbox"] {
+            width: 18px;
+            height: 18px;
+            margin-right: 10px;
+            cursor: pointer;
+        }
+
+        .remember-me label {
+            color: #666;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
+        @media (max-width: 480px) {
+            .login-container {
+                padding: 40px 30px;
+            }
+
+            .login-header h1 {
+                font-size: 28px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-header">
+            <div class="login-icon">🐶</div>
+            <h1>Dog Cam Login</h1>
+            <p>Enter your credentials to continue</p>
+        </div>
+
+        {% if error %}
+        <div class="error-message">
+            {{ error }}
+        </div>
+        {% endif %}
+
+        <form method="POST" action="/login" autocomplete="on">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input 
+                    type="text" 
+                    id="username" 
+                    name="username" 
+                    autocomplete="username"
+                    required 
+                    autofocus
+                    placeholder="Enter your username"
+                >
+            </div>
+
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input 
+                    type="password" 
+                    id="password" 
+                    name="password" 
+                    autocomplete="current-password"
+                    required
+                    placeholder="Enter your password"
+                >
+            </div>
+
+            <div class="remember-me">
+                <input type="checkbox" id="remember" name="remember" checked>
+                <label for="remember">Keep me logged in</label>
+            </div>
+
+            <button type="submit" class="login-button">Login</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- removed tracking behavior from the Flask camera app and kept the stream manual-only
- simplified the web UI to manual pan and tilt controls with touch drag support on mobile
- added the current `servo_control_rpigpio.py` runtime and login template to the repo
- aligned Raspberry Pi service files, package metadata, and repo ignore rules with the deployed setup
- refreshed the Raspberry Pi setup and wiring documentation

## Why
The deployed Pi app had been updated directly while the repository still contained older tracking-oriented code and stale setup artifacts. This PR makes the repository the source of truth for the current manual-control camera behavior and deployment layout.

## User impact
- the website now exposes only manual camera controls
- mobile users can drag vertically for tilt and horizontally for pan
- the repo is easier to deploy because it only contains the active runtime and setup files
- `.env` remains local-only and is not added to git

## Root cause
The live Raspberry Pi instance had diverged from the repository. Tracking behavior, alternate servo implementations, and stale setup instructions were still represented in git even though the running app had already moved to a different manual-control path.

## Validation
- `python3 -m py_compile /tmp/dogo-cam-pr/dogcam_stream.py /tmp/dogo-cam-pr/servo_control_rpigpio.py /tmp/dogo-cam-pr/ky004-control.py`
- synced the cleaned tree to `/home/hidalgo-cam/dog-kotaro-cam` while preserving the existing `.env`
- `python3 -m py_compile` passed on the Raspberry Pi for `dogcam_stream.py`, `servo_control_rpigpio.py`, and `ky004-control.py`
- `dog-stream.service` restarted successfully on the Raspberry Pi and is active
